### PR TITLE
Add support for development only dependencies

### DIFF
--- a/doc/decomposer-install.scd
+++ b/doc/decomposer-install.scd
@@ -30,7 +30,8 @@ git clone, _decomposer_ will reset the repo and throw away any local changes.
 # OPTIONS
 
 *--no-dev*
-	Do not generate the outdated check in the include file
+	Do not install development-only dependencies and also do not generate the
+	outdated check in the include file
 
 # ENVIRONMENT VARIABLES
 

--- a/libexec/decomposer/decomposer-install
+++ b/libexec/decomposer/decomposer-install
@@ -3,12 +3,14 @@
 DECOMPOSER_TARGET_DIR=${DECOMPOSER_TARGET_DIR:-/var/www/libs/}
 
 INCLUDE_OUTDATED_CHECK=1
+INSTALL_DEV_DEPENDENCIES=1
 
 parse_arguments() {
   while [ "$#" -gt 0 ]; do
     case "$1" in
       "--no-dev")
         INCLUDE_OUTDATED_CHECK=0
+        INSTALL_DEV_DEPENDENCIES=0
         ;;
       *)
         printf "Unknown option %s\n" "$1"
@@ -35,6 +37,15 @@ install_library() {
   local name="$1"
   local object="$2"
   local status_text_variable="$3"
+
+  local dev
+
+  dev=$( jq -r '."development-only"' <<< "${object}" )
+
+  if [ "$dev" = "true" -a $INSTALL_DEV_DEPENDENCIES = 0 ]; then
+    printf -v "${status_text_variable}" 'development-only dependency'
+    return 2
+  fi
 
   local url version library_target_dir
 
@@ -133,6 +144,14 @@ install_library() {
 create_library_autoload() {
   local name="$1"
   local object="$2"
+
+  local dev
+
+  dev=$( jq -r '."development-only"' <<< "${object}" )
+
+  if [ "$dev" = "true" -a $INSTALL_DEV_DEPENDENCIES = 0 ]; then
+    return 2
+  fi
 
   local version library_target_dir
 

--- a/libexec/decomposer/decomposer-validate
+++ b/libexec/decomposer/decomposer-validate
@@ -52,6 +52,12 @@ validate_library() {
     return 1
   fi
 
+  if [ "$( jq 'has("development-only")' <<< "${object}" )" = 'true' ] \
+    && ! [ "$( jq -r '."development-only"|type' <<< "${object}" )" = 'boolean' ]; then
+    printf -v "${status_text_variable}" 'invalid development-only indicator'
+    return 1
+  fi
+
   if [ "$( jq 'has("revision")' <<< "${object}" )" = 'true' ] \
     && ! [ "$( jq -r '.revision|type' <<< "${object}" )" = 'string' ]; then
     printf -v "${status_text_variable}" 'invalid revision'

--- a/man/decomposer-install.1
+++ b/man/decomposer-install.1
@@ -37,7 +37,8 @@ git clone, \fIdecomposer\fR will reset the repo and throw away any local changes
 .P
 \fB--no-dev\fR
 .RS 4
-Do not generate the outdated check in the include file
+Do not install development-only dependencies and also do not generate the outdated check
+in the include file
 .P
 .RE
 .SH ENVIRONMENT VARIABLES

--- a/tests/fixtures/decomposer_json/alpha_dev.json
+++ b/tests/fixtures/decomposer_json/alpha_dev.json
@@ -1,0 +1,10 @@
+"Alpha": {
+    "url": "${TEST_REPOS_DIR}/alpha-lib",
+    "revision": "master",
+    "version": "1.0",
+    "psr4": {
+        "prefix": "alpha-lib",
+        "search-path": "/src/alpha/"
+    },
+    "development-only": true
+}

--- a/tests/fixtures/decomposer_json/alpha_nodev.json
+++ b/tests/fixtures/decomposer_json/alpha_nodev.json
@@ -1,0 +1,10 @@
+"Alpha": {
+    "url": "${TEST_REPOS_DIR}/alpha-lib",
+    "revision": "master",
+    "version": "1.0",
+    "psr4": {
+        "prefix": "alpha-lib",
+        "search-path": "/src/alpha/"
+    },
+    "development-only": false
+}

--- a/tests/fixtures/decomposer_json/beta_dev.json
+++ b/tests/fixtures/decomposer_json/beta_dev.json
@@ -1,0 +1,8 @@
+"Beta": {
+    "url": "${TEST_REPOS_DIR}/beta-lib",
+    "version": "1.0",
+    "psr0": {
+        "path": "/src/beta/"
+    },
+    "development-only": true
+}

--- a/tests/fixtures/decomposer_json/beta_dev_not_boolean.json
+++ b/tests/fixtures/decomposer_json/beta_dev_not_boolean.json
@@ -1,0 +1,8 @@
+"Beta": {
+    "url": "${TEST_REPOS_DIR}/beta-lib",
+    "version": "1.0",
+    "psr0": {
+        "path": "/src/beta/"
+    },
+    "development-only": "true"
+}

--- a/tests/helpers/assertions.bash
+++ b/tests/helpers/assertions.bash
@@ -22,6 +22,13 @@ assert_lib_installed() {
   [ "${expected_head_hash}" == "${result_head_hash}" ]
 }
 
+assert_lib_not_installed() {
+  local lib_name_version="$1"
+  local expected_head_hash="$2"
+
+  ! [ -d "${DECOMPOSER_TARGET_DIR}/${lib_name_version}" ]
+}
+
 assert_lib_contains() {
   local lib_name_version="$1"
   local revision="$2"
@@ -51,6 +58,13 @@ assert_lib_autoload_file() {
   )
 
   [ "${expected_content}" == "${result_content}" ]
+}
+
+assert_lib_no_autoload_file() {
+  local lib_name_version="$1"
+  local fixture_name="$2"
+
+  ! [ -f "${DECOMPOSER_TARGET_DIR}/${lib_name_version}.php" ]
 }
 
 assert_project_autoload_file_without_check() {

--- a/tests/install.bats
+++ b/tests/install.bats
@@ -261,3 +261,34 @@ SUITE_NAME=$( test_suite_name )
   assert_project_autoload_file Alpha-1.0
 }
 
+@test "${SUITE_NAME}: single new PSR-4 library (not development-only)" {
+  create_decomposer_json alpha_nodev
+
+  local alpha_lib_revision_hash="$( create_repository alpha-lib )"
+
+  run_decomposer install
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "Installing Alpha...done" ]
+
+  assert_lib_installed Alpha-1.0 "${alpha_lib_revision_hash}"
+
+  assert_lib_autoload_file Alpha-1.0 alpha_psr4
+
+  assert_project_autoload_file Alpha-1.0
+}
+
+@test "${SUITE_NAME}: single new PSR-4 library (development-only)" {
+  create_decomposer_json alpha_dev
+
+  local alpha_lib_revision_hash="$( create_repository alpha-lib )"
+
+  run_decomposer install
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "Installing Alpha...done" ]
+
+  assert_lib_installed Alpha-1.0 "${alpha_lib_revision_hash}"
+
+  assert_lib_autoload_file Alpha-1.0 alpha_psr4
+
+  assert_project_autoload_file Alpha-1.0
+}

--- a/tests/install_no_dev.bats
+++ b/tests/install_no_dev.bats
@@ -59,3 +59,33 @@ SUITE_NAME=$( test_suite_name )
 
   assert_project_autoload_file_without_check Alpha-1.0 Beta-1.0
 }
+
+@test "${SUITE_NAME}: single new PSR-4 library (not development-only)" {
+  create_decomposer_json alpha_nodev
+
+  local alpha_lib_revision_hash="$( create_repository alpha-lib )"
+
+  run_decomposer install --no-dev
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "Installing Alpha...done" ]
+
+  assert_lib_installed Alpha-1.0 "${alpha_lib_revision_hash}"
+
+  assert_lib_autoload_file Alpha-1.0 alpha_psr4
+
+  assert_project_autoload_file_without_check Alpha-1.0
+}
+
+@test "${SUITE_NAME}: single new PSR-4 library (development-only)" {
+  create_decomposer_json alpha_dev
+
+  run_decomposer install --no-dev
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "Installing Alpha...skipped (development-only dependency)" ]
+
+  assert_lib_not_installed Alpha-1.0 "${alpha_lib_revision_hash}"
+
+  assert_lib_no_autoload_file Alpha-1.0
+
+  assert_project_autoload_file_without_check Alpha-1.0
+}

--- a/tests/validate.bats
+++ b/tests/validate.bats
@@ -17,6 +17,16 @@ SUITE_NAME=$( test_suite_name )
   [ "${lines[2]}" = "Validating Gamma...OK" ]
 }
 
+@test "${SUITE_NAME}: valid decomposer.json file with development-only indicator" {
+  create_decomposer_json alpha_psr4 beta_dev gamma_psr0
+
+  run_decomposer validate
+  [ "${status}" -eq 0 ]
+  [ "${lines[0]}" = "Validating Alpha...OK" ]
+  [ "${lines[1]}" = "Validating Beta...OK" ]
+  [ "${lines[2]}" = "Validating Gamma...OK" ]
+}
+
 @test "${SUITE_NAME}: decomposer.json doesn't contain JSON content" {
   create_decomposer_json not_json_content
 
@@ -120,5 +130,15 @@ SUITE_NAME=$( test_suite_name )
   [ "${status}" -eq 1 ]
   [ "${lines[0]}" = "Validating Alpha...OK" ]
   [ "${lines[1]}" = "Validating Beta...FAIL (conflicting psr0 and psr4)" ]
+  [ "${lines[2]}" = "Validating Gamma...OK" ]
+}
+
+@test "${SUITE_NAME}: library dev not a boolean" {
+  create_decomposer_json alpha_psr4 beta_dev_not_boolean gamma_psr0
+
+  run_decomposer validate
+  [ "${status}" -eq 1 ]
+  [ "${lines[0]}" = "Validating Alpha...OK" ]
+  [ "${lines[1]}" = "Validating Beta...FAIL (invalid development-only indicator)" ]
   [ "${lines[2]}" = "Validating Gamma...OK" ]
 }


### PR DESCRIPTION
Add support for an "only for development" indicator in `decomposer.json`.

Example:
```
    "Mockery": {
        "url": "https://github.com/mockery/mockery.git",
        "version": "1.5.1",
        "psr0": {
            "path": "/library/"
        },
        "dev": true
    }
```